### PR TITLE
fix(package): mark more dependencies as not being devDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,14 +83,12 @@
 		"@supportclass/tsconfig-base": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@supportclass/tsconfig-base/-/tsconfig-base-1.0.2.tgz",
-			"integrity": "sha512-rCzW8gXhhj11cNCIrmfj9auX2nyclQKeHfIj8dWIGj/B2/mfN2gLU8Z8fi1eROCnEV9BvFeebJMA/YJ/lljPEw==",
-			"dev": true
+			"integrity": "sha512-rCzW8gXhhj11cNCIrmfj9auX2nyclQKeHfIj8dWIGj/B2/mfN2gLU8Z8fi1eROCnEV9BvFeebJMA/YJ/lljPEw=="
 		},
 		"@types/convict": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/@types/convict/-/convict-4.2.1.tgz",
-			"integrity": "sha512-2cd51m3i0yeY1i3dKxcqJKeS5Q4jZnjP37OseoNeIX1OM0AhmGPuuYmwJ9OqtsU35YrREQxdb2VeX5sM3cwGMQ==",
-			"dev": true
+			"integrity": "sha512-2cd51m3i0yeY1i3dKxcqJKeS5Q4jZnjP37OseoNeIX1OM0AhmGPuuYmwJ9OqtsU35YrREQxdb2VeX5sM3cwGMQ=="
 		},
 		"@types/eslint-visitor-keys": {
 			"version": "1.0.0",
@@ -130,8 +128,7 @@
 		"@types/node": {
 			"version": "12.7.5",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-			"integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
-			"dev": true
+			"integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -142,14 +139,12 @@
 		"@types/shortid": {
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/shortid/-/shortid-0.0.29.tgz",
-			"integrity": "sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps=",
-			"dev": true
+			"integrity": "sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps="
 		},
 		"@types/socket.io-client": {
 			"version": "1.4.32",
 			"resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.32.tgz",
-			"integrity": "sha512-Vs55Kq8F+OWvy1RLA31rT+cAyemzgm0EWNeax6BWF8H7QiiOYMJIdcwSDdm5LVgfEkoepsWkS+40+WNb7BUMbg==",
-			"dev": true
+			"integrity": "sha512-Vs55Kq8F+OWvy1RLA31rT+cAyemzgm0EWNeax6BWF8H7QiiOYMJIdcwSDdm5LVgfEkoepsWkS+40+WNb7BUMbg=="
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "1.13.0",
@@ -266,8 +261,7 @@
 		"arg": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
-			"integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
-			"dev": true
+			"integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw=="
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -369,8 +363,7 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"caller-callsite": {
 			"version": "2.0.0",
@@ -743,8 +736,7 @@
 		"diff": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-			"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-			"dev": true
+			"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -1985,8 +1977,7 @@
 		"make-error": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
-			"dev": true
+			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
 		},
 		"memorystream": {
 			"version": "0.3.1",
@@ -2728,14 +2719,12 @@
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 		},
 		"source-map-support": {
 			"version": "0.5.13",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
 			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -2994,7 +2983,6 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
 			"integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
-			"dev": true,
 			"requires": {
 				"arg": "^4.1.0",
 				"diff": "^4.0.1",
@@ -3030,14 +3018,12 @@
 		"type-fest": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
-			"integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
-			"dev": true
+			"integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
 		},
 		"typescript": {
 			"version": "3.6.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-			"integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
-			"dev": true
+			"integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
 		},
 		"uri-js": {
 			"version": "4.2.2",
@@ -3245,8 +3231,7 @@
 		"yn": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -27,21 +27,18 @@
   "devDependencies": {
     "@gamesdonequick/eslint-config": "^1.0.2",
     "@gamesdonequick/prettier-config": "^2.0.0",
+    "eslint": "^6.3.0",
+    "husky": "^3.0.5",
+    "lint-staged": "^9.2.5",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^1.18.2"
+  },
+  "dependencies": {
     "@supportclass/tsconfig-base": "^1.0.2",
     "@types/convict": "^4.2.1",
     "@types/node": "^12.7.5",
     "@types/shortid": "0.0.29",
     "@types/socket.io-client": "^1.4.32",
-    "eslint": "^6.3.0",
-    "husky": "^3.0.5",
-    "lint-staged": "^9.2.5",
-    "npm-run-all": "^4.1.5",
-    "prettier": "^1.18.2",
-    "ts-node": "^8.3.0",
-    "type-fest": "^0.7.1",
-    "typescript": "^3.6.3"
-  },
-  "dependencies": {
     "casparcg-connection": "^4.7.0",
     "convict": "^5.1.0",
     "fast-deep-equal": "^2.0.1",
@@ -49,7 +46,10 @@
     "socket.io-client": "^2.2.0",
     "strict-event-emitter-types": "^2.0.0",
     "winston": "^3.2.1",
-    "winston-transport": "^4.3.0"
+    "winston-transport": "^4.3.0",
+    "ts-node": "^8.3.0",
+    "type-fest": "^0.7.1",
+    "typescript": "^3.6.3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Because we run this application via `ts-node`, things like all our `@types` are actually prod deps that every installation needs at runtime.